### PR TITLE
Better CacheInfoBox screen placement; fixed repeating animation of infoBox

### DIFF
--- a/src/components/CacheInfoBox.js
+++ b/src/components/CacheInfoBox.js
@@ -5,12 +5,15 @@ import {connect} from "react-redux";
 import ClaimButton from "./ClaimButton";
 import {OverlayView} from "react-google-maps";
 import {setActiveCache} from "../actions/uiActions";
+import { compose, withState } from "recompose";
+
+
 
 import "./CacheInfoBox.css";
 
 let getPixelPositionOffset = (width, height) => ({
-  x: 16,
-  y: -(height / 2),
+  x: -(width+182),
+  y: -(height +222),
 });
 let mapDispatchtoProps = dispatch => {
   let closePopup = () => {
@@ -20,13 +23,14 @@ let mapDispatchtoProps = dispatch => {
 };
 
 let CacheInfoBox = ({createdOn, claimedOn, name, lat, lng, description,
-  image_url="/No_image_available.svg", closePopup, distance, claims, id}) => {
+  image_url="/No_image_available.svg", closePopup, distance, claims, id, infoBoxShowing, setInfoBoxShowing}) => {
 
   //Database will return null if an image is not set but defualt parameter
   //triggers only on undefined
   if (image_url === null) {
     image_url =  "/No_image_available.svg";
   }
+console.log('this.infoBoxShowing: ', infoBoxShowing);
 
   return (
     <OverlayView
@@ -34,7 +38,10 @@ let CacheInfoBox = ({createdOn, claimedOn, name, lat, lng, description,
       mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
       getPixelPositionOffset={getPixelPositionOffset}
     >
-      <div className="infoBox zoom">
+      <div className={infoBoxShowing ? 'infoBox zoom' : 'infoBox nozoom'}
+      onAnimationStart={() => setInfoBoxShowing(true)}
+      onAnimationEnd={() => setInfoBoxShowing(false)}
+      >
         <div className="infoBox_header">
           <h3>{name}</h3>
           <button type="button" className="close_button" onClick={closePopup}>
@@ -69,6 +76,10 @@ CacheInfoBox.propTypes = {
 
 };
 
-let connectedCacheInfoBox = connect(null, mapDispatchtoProps)(CacheInfoBox);
+let connectedCacheInfoBox = connect(null, mapDispatchtoProps);
+let enhancedConnectedCacheInfoBox = compose(
+  withState('infoBoxShowing','setInfoBoxShowing',true),
+  connectedCacheInfoBox
+)(CacheInfoBox);
 
-export default connectedCacheInfoBox;
+export default enhancedConnectedCacheInfoBox;

--- a/src/index.css
+++ b/src/index.css
@@ -486,7 +486,7 @@ hr {
 /*------------------*/
 
 .route-container {
-  min-height: 950px;
+  /* min-height: 950px; */
 }
 
 .Players {


### PR DESCRIPTION
… mostly
Adjusted where the CacheInfoBox displays on the screen after clicking a treasure box Marker so they more consistently show up on the screen without requiring users to scroll to see the info (it doesn't fix it completely, but they're generally much more centered on the screen.)
Also improved the tendency for the infoboxes to repeatedly animate after opening and on map movements. They should no longer re-animate on map-scrolls and should stop animating after finishing their first animation. I noticed that they still sometimes double-animate on the first time after hard-reloading the page, but it's a great improvement.