### PR TITLE
Add Heroku postbuild script to shorten startup time

### DIFF
--- a/appStart
+++ b/appStart
@@ -1,0 +1,3 @@
+#! /usr/bin/env sh
+cd server;
+node index.js;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "heroku-postbuild": "appStart"
   }
 }


### PR DESCRIPTION
Deployment on Heroku seems broken again; the app tries to start before finishing the build, so it times out. Adding "heroku-postbuild" to the package.json file _should_ make it build first, _then_ try to run. @TerryRPatterson -- You had a working method before, do you think this would work as well?